### PR TITLE
Fixed the MarkdownHeaderTextSplitter and it's test to match closer to the original implementation 

### DIFF
--- a/src/Databases/Sqlite/src/SQLiteVectorStore.cs
+++ b/src/Databases/Sqlite/src/SQLiteVectorStore.cs
@@ -37,7 +37,7 @@ public sealed class SQLiteVectorStore : VectorStore, IDisposable
         string tableName = "vectors",
         TextSplitter? textSplitter = null)
     {
-        using var vectorStore = new SQLiteVectorStore(filename,tableName,embeddings);
+        var vectorStore = new SQLiteVectorStore(filename,tableName,embeddings);
         textSplitter ??= new CharacterTextSplitter();
         VectorStoreIndexCreator indexCreator = new VectorStoreIndexCreator(vectorStore, textSplitter);
         var index = await indexCreator.FromDocumentsAsync(documents).ConfigureAwait(false);

--- a/src/Splitters/Abstractions/test/Tests.MarkdownHeader.cs
+++ b/src/Splitters/Abstractions/test/Tests.MarkdownHeader.cs
@@ -2,6 +2,7 @@
 
 namespace LangChain.Splitters;
 
+[TestFixture]
 public partial class Tests
 {
     [Test]
@@ -35,7 +36,23 @@ some text
 ";
         var splitter = new MarkdownHeaderTextSplitter();
         var res = splitter.SplitText(md);
-        res.Count.Should().Be(1);
+        res.Count.Should().Be(2);
         res[0].Split("\n")[0].Should().Be("Header 1");
+        
+
+    }
+
+    [Test]
+    public void TestMarkdown3()
+    {
+        var md = "# Foo\n\n ## Bar\n\nHi this is Jim  \nHi this is Joe\n\n ## Baz\n\n Hi this is Molly";
+
+        var splitter = new MarkdownHeaderTextSplitter(includeHeaders: false);
+        var res = splitter.SplitText(md);
+        res[0].Should().Be("Hi this is Jim\nHi this is Joe");
+        res[1].Should().Be("Hi this is Molly");
+
+
+
     }
 }


### PR DESCRIPTION
closes #140 
it is not complete replica since we don't have metadata here, but `include heades` parameter should be a good alternative