### PR TITLE
bug fix for VectorSearchType.SimilarityScoreThreshold

### DIFF
--- a/src/Core/src/Retrievers/VectorStoreRetriever.cs
+++ b/src/Core/src/Retrievers/VectorStoreRetriever.cs
@@ -36,6 +36,7 @@ public class VectorStoreRetriever : BaseRetriever
         float? scoreThreshold = null)
     {
         SearchType = searchType;
+        ScoreThreshold = scoreThreshold;
 
         if (SearchType == VectorSearchType.SimilarityScoreThreshold && ScoreThreshold == null)
             throw new ArgumentException($"ScoreThreshold required for {SearchType}");

--- a/src/Core/src/Retrievers/VectorStoreRetriever.cs
+++ b/src/Core/src/Retrievers/VectorStoreRetriever.cs
@@ -43,8 +43,6 @@ public class VectorStoreRetriever : BaseRetriever
 
         EmbeddingModel = embeddingModel;
         VectorCollection = vectorCollection;
-        SearchType = searchType;
-        ScoreThreshold = scoreThreshold;
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
initializing ScoreThreshold value.
Currently throwing an argument null exception

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced the retrieval system by introducing a `scoreThreshold` parameter to refine result accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->