### PR TITLE
fix model groq empty. change default max tokens.

### DIFF
--- a/src/Providers/Groq/src/GroqChatModel.cs
+++ b/src/Providers/Groq/src/GroqChatModel.cs
@@ -18,6 +18,7 @@ public class GroqChatModel(
     {
         request = request ?? throw new ArgumentNullException(nameof(request));
         var prompt = ToPrompt(request.Messages);
+        Provider.Api.SetModel(Id);
         var watch = Stopwatch.StartNew();
         var response = await Provider.Api.CreateChatCompletionAsync(prompt).ConfigureAwait(false);
 

--- a/src/Providers/Groq/src/GroqConfiguration.cs
+++ b/src/Providers/Groq/src/GroqConfiguration.cs
@@ -6,7 +6,7 @@ public class GroqConfiguration
     public string ApiKey { get; set; } = string.Empty;
     public string ModelId { get; set; } = string.Empty;
     public double Temperature { get; set; } = 0.5;
-    public int MaxTokens { get; set; } = int.MaxValue;
+    public int MaxTokens { get; set; } = 8192 ;
     public double TopP { get; set; } = 1.0;
     public string Stop { get; set; } = "NONE";
     public int StructuredRetryPolicy { get; set; } = 5;

--- a/src/Providers/Groq/src/GroqProvider.cs
+++ b/src/Providers/Groq/src/GroqProvider.cs
@@ -15,9 +15,8 @@ public class GroqProvider : Provider
     {
         configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
         var apiKey = configuration.ApiKey ?? throw new ArgumentException("ApiKey is not defined", nameof(configuration));
-        var apiModel = configuration.ModelId ?? throw new ArgumentException("ModelId is not defined", nameof(configuration));
 
-        Api = new GroqClient(apiKey, apiModel)
+        Api = new GroqClient(apiKey, configuration.ModelId)
             .SetTemperature(configuration.Temperature)
             .SetMaxTokens(configuration.MaxTokens)
             .SetTopP(configuration.TopP)

--- a/src/Providers/Groq/test/GroqTests.cs
+++ b/src/Providers/Groq/test/GroqTests.cs
@@ -12,14 +12,15 @@ public partial class GroqTests
         var config = new GroqConfiguration()
         {
             ApiKey = Environment.GetEnvironmentVariable("GROQ_API_KEY") ??
-                throw new InconclusiveException("GROQ_API_KEY is not set."),
-            ModelId = "llama3-70b-8192"
+                throw new InconclusiveException("GROQ_API_KEY is not set.")
         };
 
         var provider = new GroqProvider(config);
         var model = new Llama370B(provider);
 
         string answer = await model.GenerateAsync("Generate some random name:");
+
+        answer.Should().NotBeNull();
 
         Console.WriteLine(answer);
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved model selection process for chat completions.

- **Enhancements**
  - Adjusted `MaxTokens` configuration to a maximum of 8192 for better performance and resource management.

- **Bug Fixes**
  - Ensured proper model ID usage in GroqProvider to prevent misconfiguration issues.

- **Tests**
  - Enhanced test reliability by adding assertions to verify non-null responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->