### PR TITLE
Fix: #343 - LLamaSharpEmbeddings Exception: EmbeddingMode must be true

### DIFF
--- a/src/Providers/LLamaSharp/src/LLamaSharpEmbeddings.cs
+++ b/src/Providers/LLamaSharp/src/LLamaSharpEmbeddings.cs
@@ -1,5 +1,5 @@
-﻿using LLama.Common;
-using LLama;
+﻿using LLama;
+using LLama.Common;
 
 namespace LangChain.Providers.LLamaSharp;
 
@@ -23,7 +23,8 @@ public sealed class LLamaSharpEmbeddings
         return new LLamaSharpEmbeddings(new LLamaSharpConfiguration
         {
             PathToModelFile = path,
-            Temperature = temperature
+            Temperature = temperature,
+            EmbeddingMode = true
         });
     }
 
@@ -43,6 +44,7 @@ public sealed class LLamaSharpEmbeddings
         {
             ContextSize = (uint)configuration.ContextSize,
             Seed = (uint)configuration.Seed,
+            Embeddings = configuration.EmbeddingMode
         };
         _model = LLamaWeights.LoadFromFile(parameters);
         _configuration = configuration;


### PR DESCRIPTION
Fixes tryAGI/LangChain#343

Fixed by passing the EmbeddingMode configuration from LlamaSharpConfiguration to the ModelParams. Also this propery is setted true in the FromPath() static method, otherwise this method will crash too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new `EmbeddingMode` property to enhance the configuration of embeddings.
  - Added initialization and assignment for the `EmbeddingMode` property, allowing users to set embedding modes more flexibly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->