### PR TITLE
fix set google credentials

### DIFF
--- a/src/Providers/Google.VertexAI/src/VertexAIConfiguration.cs
+++ b/src/Providers/Google.VertexAI/src/VertexAIConfiguration.cs
@@ -8,7 +8,7 @@ namespace LangChain.Providers.Google.VertexAI
         public const string SectionName = "VertexAI";
         public string Location { get; set; } = "us-central1";
         public string Publisher { get; set; } = "google";
-        public GoogleCredential? GoogleCredential { get; set; } = GoogleCredential.GetApplicationDefault();
+        public GoogleCredential? GoogleCredential { get; set; }
         public GenerationConfig? GenerationConfig { get; set; }
     }
 }

--- a/src/Providers/Google.VertexAI/src/VertexAIProvider.cs
+++ b/src/Providers/Google.VertexAI/src/VertexAIProvider.cs
@@ -12,6 +12,7 @@ namespace LangChain.Providers.Google.VertexAI
             Configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
             Api = new PredictionServiceClientBuilder
             {
+                GoogleCredential = Configuration.GoogleCredential,
                 Endpoint = $"{Configuration.Location}-aiplatform.googleapis.com"
             }.Build();
         }


### PR DESCRIPTION
I forgot to set the credentials in the client builder.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - Enhanced credential management for Google AI Platform integration, ensuring proper configuration during initialization.
- **Bug Fixes**
    - Corrected instantiation behavior of `VertexAIConfiguration` by removing default value for `GoogleCredential`, requiring explicit assignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->