### PR TITLE
fix: updated Amazon Bedrock Anthropic Claude3 models to include anthropic_version in body request

### DIFF
--- a/src/Providers/Amazon.Bedrock/src/Chat/AnthropicClaude3ChatModel.cs
+++ b/src/Providers/Amazon.Bedrock/src/Chat/AnthropicClaude3ChatModel.cs
@@ -115,6 +115,7 @@ public class AnthropicClaude3ChatModel(
 
         var bodyJson = new JsonObject
         {
+            ["anthropic_version"] = "bedrock-2023-05-31",
             ["max_tokens"] = usedSettings.MaxTokens!.Value,
             ["messages"] = new JsonArray
             {

--- a/src/Providers/Amazon.Bedrock/test/BedrockTests.cs
+++ b/src/Providers/Amazon.Bedrock/test/BedrockTests.cs
@@ -29,9 +29,9 @@ public class BedrockTests
     {
         var provider = new BedrockProvider();
         //var llm = new Jurassic2MidModel(provider);
-        //var llm = new ClaudeV21Model(provider);
+        var llm = new Claude35SonnetModel(provider);
         //var llm = new Mistral7BInstruct(provider);
-        var llm = new JambaInstructModel(provider);
+        //var llm = new JambaInstructModel(provider);
 
         var template = "What is a good name for a company that makes {product}?";
         var prompt = new PromptTemplate(new PromptTemplateInput(template, new List<string>(1) { "product" }));


### PR DESCRIPTION
[…opic_version in body request](fix: updated Amazon Bedrock Anthropic Claude3 models to include anthropic_version in body request)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the Anthropic API version to "bedrock-2023-05-31" for enhanced clarity and compatibility.
	- Switched to testing the `Claude35SonnetModel` for improved performance and relevance in test cases. 

- **Bug Fixes**
	- Removed commented-out instantiation of the `JambaInstructModel` to streamline the test setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->