### PR TITLE
Update libraries to latest stable versions - PdfPig to v.0.1.9 and Microsoft.Extensions.Http to v.8.0.1

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -42,7 +42,7 @@
     <PackageVersion Include="Npgsql" Version="8.0.4" />
     <PackageVersion Include="NUnit" Version="4.2.2" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.6.0" />
-    <PackageVersion Include="PdfPig" Version="0.1.8" />
+    <PackageVersion Include="PdfPig" Version="0.1.9" />
     <PackageVersion Include="PolySharp" Version="1.14.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -57,7 +57,7 @@
     <PackageVersion Include="System.Text.Json" Version="8.0.5" />
     <PackageVersion Include="System.ValueTuple" Version="4.5.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
     <PackageVersion Include="MinVer" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Closes #468 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated package versions for improved performance and security:
		- `PdfPig` upgraded from `0.1.8` to `0.1.9`
		- `Microsoft.Extensions.Http` upgraded from `8.0.0` to `8.0.1`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->