### PR TITLE
Fixing the MarkdownHeaderTextSplitter dealling with lines just contianing #s

### DIFF
--- a/src/Splitters/Abstractions/src/Text/MarkdownHeaderTextSplitter.cs
+++ b/src/Splitters/Abstractions/src/Text/MarkdownHeaderTextSplitter.cs
@@ -122,6 +122,8 @@ public class MarkdownHeaderTextSplitter : TextSplitter
         len = 0;
         foreach (var header in _headersToSplitOn)
         {
+            if (line.Length <= header.Length + 1)
+                return false;//Empty lines starting with #s should not be considered as headers. Removing this line would result in exceptions in that conditions
             if (line.Trim().StartsWith(header, StringComparison.Ordinal) && line[header.Length] == ' ')
             {
                 len = header.Length;


### PR DESCRIPTION
This change prevents errors when the markdown file includes lines that start with # but have no following characters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of header detection to prevent exceptions with empty lines starting with header symbols.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->