### PR TITLE
Text splitter bugfixes

### DIFF
--- a/src/Splitters/Abstractions/src/Text/CharacterTextSplitter.cs
+++ b/src/Splitters/Abstractions/src/Text/CharacterTextSplitter.cs
@@ -15,6 +15,8 @@ public class CharacterTextSplitter(
     {
         text = text ?? throw new ArgumentNullException(nameof(text));
 
+        text = text.Replace("\r", ""); // some people are using windows
+
         List<string> splits;
         if (separator != null)
         {

--- a/src/Splitters/Abstractions/src/Text/MarkdownHeaderTextSplitter.cs
+++ b/src/Splitters/Abstractions/src/Text/MarkdownHeaderTextSplitter.cs
@@ -76,7 +76,7 @@ public class MarkdownHeaderTextSplitter : TextSplitter
                 {
                     var existingHeader = currentHeader.Split('|');
 
-                    string prevHeader = string.Join("|", existingHeader.Take(existingHeader.Length - 1));
+                    string prevHeader = string.Join("|", existingHeader.Take(existingHeader.Length - (1 - hLen + currentHeaderLen)));
                     currentHeader = prevHeader + "|" + strippedLine.TrimStart('#').Trim();
                     currentHeaderLen = hLen;
                     continue;

--- a/src/Splitters/Abstractions/src/Text/RecursiveCharacterTextSplitter.cs
+++ b/src/Splitters/Abstractions/src/Text/RecursiveCharacterTextSplitter.cs
@@ -19,6 +19,8 @@ public class RecursiveCharacterTextSplitter(
     {
         text = text ?? throw new ArgumentNullException(nameof(text));
 
+        text = text.Replace("\r", ""); // some people are using windows
+
         List<string> finalChunks = new List<string>();
         string separator = _separators[_separators.Count - 1];
 

--- a/src/Splitters/Abstractions/test/Resources/markdown_test_material.md
+++ b/src/Splitters/Abstractions/test/Resources/markdown_test_material.md
@@ -1,0 +1,71 @@
+# Header A
+
+Text A
+
+## Header A.A
+
+Text A.A
+
+## Header A.B
+
+Text A.B
+
+### Header A.B.A
+
+Text A.B.A
+
+### Header A.B.B
+
+Text A.B.B
+
+### Header A.B.C
+
+Text A.B.C
+
+## Header A.C
+
+Text A.C
+
+### Header A.C.A
+
+Text A.C.A
+
+### Header A.C.B
+
+Text A.C.B
+
+# Header B
+
+Text B
+
+## Header B.A
+
+Text B.A
+
+## Header B.B
+
+Text B.B
+
+### Header B.B.A
+
+Text B.B.A
+
+### Header B.B.B
+
+Text B.B.B
+
+## Header B.C
+
+Text B.C
+
+### Header B.C.A
+
+Text B.C.A
+
+### Header B.C.B
+
+Text B.C.B
+
+### Header B.C.C
+
+Text B.C.C

--- a/src/Splitters/Abstractions/test/Tests.MarkdownHeader.cs
+++ b/src/Splitters/Abstractions/test/Tests.MarkdownHeader.cs
@@ -61,4 +61,69 @@ Hi this is Joe
         res[0].Should().Be("Hi this is Jim\nHi this is Joe");
         res[1].Should().Be("Hi this is Molly");
     }
+
+    [Test]
+    public void TestMarkdown4()
+    {
+        var md = H.Resources.markdown_test_material_md.AsString();
+
+        var splitter = new MarkdownHeaderTextSplitter();
+        var res = splitter.SplitText(md);
+
+        res.Count.Should().Be(18);
+
+        res[0].Split("\n")[0].Should().Be("Header A");
+        res[0].Split("\n")[1].Should().Be("Text A");
+
+        res[1].Split("\n")[0].Should().Be("Header A: Header A.A");
+        res[1].Split("\n")[1].Should().Be("Text A.A");
+        
+        res[2].Split("\n")[0].Should().Be("Header A: Header A.B");
+        res[2].Split("\n")[1].Should().Be("Text A.B");
+
+        res[3].Split("\n")[0].Should().Be("Header A: Header A.B: Header A.B.A");
+        res[3].Split("\n")[1].Should().Be("Text A.B.A");
+
+        res[4].Split("\n")[0].Should().Be("Header A: Header A.B: Header A.B.B");
+        res[4].Split("\n")[1].Should().Be("Text A.B.B");
+
+        res[5].Split("\n")[0].Should().Be("Header A: Header A.B: Header A.B.C");
+        res[5].Split("\n")[1].Should().Be("Text A.B.C");
+
+        res[6].Split("\n")[0].Should().Be("Header A: Header A.C");
+        res[6].Split("\n")[1].Should().Be("Text A.C");
+
+        res[7].Split("\n")[0].Should().Be("Header A: Header A.C: Header A.C.A");
+        res[7].Split("\n")[1].Should().Be("Text A.C.A");
+
+        res[8].Split("\n")[0].Should().Be("Header A: Header A.C: Header A.C.B");
+        res[8].Split("\n")[1].Should().Be("Text A.C.B");
+
+        res[9].Split("\n")[0].Should().Be("Header B");
+        res[9].Split("\n")[1].Should().Be("Text B");
+
+        res[10].Split("\n")[0].Should().Be("Header B: Header B.A");
+        res[10].Split("\n")[1].Should().Be("Text B.A");
+
+        res[11].Split("\n")[0].Should().Be("Header B: Header B.B");
+        res[11].Split("\n")[1].Should().Be("Text B.B");
+
+        res[12].Split("\n")[0].Should().Be("Header B: Header B.B: Header B.B.A");
+        res[12].Split("\n")[1].Should().Be("Text B.B.A");
+
+        res[13].Split("\n")[0].Should().Be("Header B: Header B.B: Header B.B.B");
+        res[13].Split("\n")[1].Should().Be("Text B.B.B");
+
+        res[14].Split("\n")[0].Should().Be("Header B: Header B.C");
+        res[14].Split("\n")[1].Should().Be("Text B.C");
+
+        res[15].Split("\n")[0].Should().Be("Header B: Header B.C: Header B.C.A");
+        res[15].Split("\n")[1].Should().Be("Text B.C.A");
+
+        res[16].Split("\n")[0].Should().Be("Header B: Header B.C: Header B.C.B");
+        res[16].Split("\n")[1].Should().Be("Text B.C.B");
+
+        res[17].Split("\n")[0].Should().Be("Header B: Header B.C: Header B.C.C");
+        res[17].Split("\n")[1].Should().Be("Text B.C.C");
+    }
 }


### PR DESCRIPTION
* additional hardening against running on windows (removing instances of "\r" from the text to be split) for the text splitters that did not already have this.
* fixed a bug in the MarkdownHeaderTextSplitter where the header breadcrumb line was not losing the proper number of segments on depth reduction (it only ever removed 1 segment, regardless of how much less deep the next header was than the previous one).
* added a test to validate that abovementioned bug was fixed.