### PR TITLE
Add Requesty provider to the CLI

### DIFF
--- a/src/Cli/src/Helpers.cs
+++ b/src/Cli/src/Helpers.cs
@@ -57,6 +57,7 @@ internal static class Helpers
         Uri? endpoint = provider switch
         {
             Provider.Free or Provider.OpenRouter => new Uri(tryAGI.OpenAI.CustomProviders.OpenRouterBaseUrl),
+            Provider.Requesty => new Uri("https://router.requesty.ai/v1"),
             _ => null,
         };
         model = model switch
@@ -74,6 +75,8 @@ internal static class Helpers
                 throw new InvalidOperationException("OPENAI_API_KEY environment variable is not set."),
             Provider.OpenRouter or Provider.Free => Environment.GetEnvironmentVariable("OPENROUTER_API_KEY") ??
                 throw new InvalidOperationException("OPENROUTER_API_KEY environment variable is not set."),
+            Provider.Requesty => Environment.GetEnvironmentVariable("REQUESTY_API_KEY") ??
+                throw new InvalidOperationException("REQUESTY_API_KEY environment variable is not set."),
             _ => throw new NotImplementedException(),
         };
 

--- a/src/Cli/src/Models/Provider.cs
+++ b/src/Cli/src/Models/Provider.cs
@@ -4,6 +4,7 @@ internal enum Provider
 {
     OpenAi,
     OpenRouter,
+    Requesty,
     Anthropic,
     Free,
 }


### PR DESCRIPTION
Adds Requesty (https://requesty.ai) as a provider option to the CLI (`src/Cli`), mirroring the existing `Provider.OpenRouter`.

- `src/Cli/src/Models/Provider.cs`: new `Requesty` enum value.
- `src/Cli/src/Helpers.cs`: base-URL switch arm (`https://router.requesty.ai/v1`) and API-key switch arm (`REQUESTY_API_KEY`).

Requesty is OpenAI-compatible (`Authorization: Bearer`, `provider/model` naming), so it works through the existing OpenAI client path. `--provider requesty` resolves via the existing case-insensitive enum parsing (`Option<Provider>`), so no extra string mapping was needed. The core SDK and the integration tests are untouched. API keys: https://app.requesty.ai/api-keys

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it's not a fit.